### PR TITLE
Support using an external role to set up SSL mid-role.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 # Where should the role find ssl certificates to copy to the remote host (relative from where ansible-playbook is called
 # if not absolute)
 nginx_ssl_src_dir: files/ssl
+nginx_server_src_dir: templates/nginx
 
 # "flavor" of nginx to install
 nginx_flavor: full
@@ -41,5 +42,9 @@ nginx_supervisor_service_name: nginx
 # enable ipv6 for the default vhost?
 nginx_enable_default_ipv6: true
 
-# additional nginx config files to install
-nginx_configs: [ ]
+# server block template files to install
+nginx_servers: "{{ nginx_configs | default([]) }}"
+#nginx_ssl_servers: []
+
+__nginx_ssl: "{{ nginx_conf_ssl_certificate is defined and nginx_conf_ssl_certificate_key is defined }}"
+__nginx_sslmode: "{{ 'external' if nginx_ssl_role is defined else 'internal' }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install and manage an nginx server.
   company: The Galaxy Project
   license: AFL v3.0
-  min_ansible_version: 1.8
+  min_ansible_version: 2.5
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,27 +32,6 @@
     - update supervisord
   when: nginx_supervisor and supervisord_conf_dir is defined
 
-- name: Install vhost configs
-  template:
-    src: templates/nginx/{{ item }}.j2
-    dest: "{{ nginx_conf_dir }}/sites-available/{{ item }}"
-    mode: 0444
-    backup: yes
-  with_items: "{{ nginx_configs }}"
-  notify:
-    - reload nginx
-    - supervisorctl reload nginx
-
-- name: Enable vhosts
-  file:
-    src: "{{ nginx_conf_dir }}/sites-available/{{ item }}"
-    dest: "{{ nginx_conf_dir }}/sites-enabled/{{ item }}"
-    state: link
-  with_items: "{{ nginx_configs }}"
-  notify:
-    - reload nginx
-    - supervisorctl reload nginx
-
 - name: Set additional config options
   template:
     src: http_options.conf.j2
@@ -73,9 +52,19 @@
   with_items: "{{ nginx_extra_configs | default([]) }}"
   when: nginx_extra_configs is defined
 
-- name: Include SSL Tasks
-  include: ssl.yml
-  when: nginx_conf_ssl_certificate is defined and nginx_conf_ssl_certificate_key is defined
+- name: Include server (vhost) tasks
+  import_tasks: server.yml
+
+- name: Include SSL configuration tasks
+  include_tasks: ssl-{{ __nginx_sslmode }}.yml
+  when: __nginx_ssl
+
+- name: Include SSL server (vhost) tasks
+  #import_tasks: server.yml
+  include_tasks: server.yml
+  vars:
+    nginx_servers: "{{ nginx_ssl_servers | default([]) }}"
+  when: nginx_ssl_servers is defined
 
 - name: Enable nginx (supervisor)
   supervisorctl:

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Install vhost configs
+  template:
+    src: "{{ nginx_server_src_dir }}/{{ item }}.j2"
+    dest: "{{ nginx_conf_dir }}/sites-available/{{ item | basename }}"
+    mode: 0444
+    backup: yes
+  with_items: "{{ nginx_servers }}"
+  notify:
+    - reload nginx
+    - supervisorctl reload nginx
+
+- name: Enable vhosts
+  file:
+    src: "{{ nginx_conf_dir }}/sites-available/{{ item | basename }}"
+    dest: "{{ nginx_conf_dir }}/sites-enabled/{{ item | basename }}"
+    state: link
+  with_items: "{{ nginx_servers }}"
+  notify:
+    - reload nginx
+    - supervisorctl reload nginx

--- a/tasks/ssl-common.yml
+++ b/tasks/ssl-common.yml
@@ -1,0 +1,34 @@
+---
+
+# Some versions of Debian set this in nginx.conf, and unlike other vars such as ssl_protocols, this does not override
+# other entires.
+- name: Disable ssl_prefer_server_ciphers in nginx.conf if set
+  lineinfile:
+    name: "{{ nginx_conf_file }}"
+    regexp: '^(\s*ssl_prefer_server_ciphers\s.*)'
+    backrefs: yes
+    line: '#\1 # commented by Ansible'
+    backup: yes
+  notify:
+    - reload nginx
+    - supervisorctl restart nginx
+
+- name: Configure server-wide SSL
+  template:
+    src: ssl.conf.j2
+    dest: "{{ nginx_conf_dir }}/conf.d/ssl.conf"
+    mode: 0444
+    backup: yes
+  notify:
+    - restart nginx
+    - supervisorctl restart nginx
+
+- name: Ensure nginx SSL directory exists
+  file:
+    path: "{{ nginx_ssl_conf_dir }}"
+    state: directory
+
+- name: Generate strong Diffie-Hellman group
+  command: openssl dhparam -out {{ nginx_ssl_conf_dir }}/dhparams.pem 2048
+  args:
+    creates: "{{ nginx_ssl_conf_dir }}/dhparams.pem"

--- a/tasks/ssl-external.yml
+++ b/tasks/ssl-external.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Flush handlers before running SSL role
+  meta: flush_handlers
+
+- name: Include SSL role
+  include_role:
+    name: "{{ nginx_ssl_role }}"
+
+- name: Include common SSL tasks
+  import_tasks: ssl-common.yml

--- a/tasks/ssl-internal.yml
+++ b/tasks/ssl-internal.yml
@@ -1,32 +1,9 @@
 ---
 
-# Some versions of Debian set this in nginx.conf, and unlike other vars such as ssl_protocols, this does not override
-# other entires.
-- name: Disable ssl_prefer_server_ciphers in nginx.conf if set
-  lineinfile:
-    name: "{{ nginx_conf_file }}"
-    regexp: '^(\s*ssl_prefer_server_ciphers\s.*)'
-    backrefs: yes
-    line: '#\1 # commented by Ansible'
-    backup: yes
-  notify:
-    - reload nginx
-    - supervisorctl restart nginx
-
 - name: Make SSL certificate/key paths absolute
   set_fact:
     nginx_conf_ssl_certificate: "{{ nginx_ssl_conf_dir ~ '/' ~ nginx_conf_ssl_certificate if nginx_conf_ssl_certificate.0 != '/' else nginx_conf_ssl_certificate }}"
     nginx_conf_ssl_certificate_key: "{{ nginx_ssl_conf_dir ~ '/' ~ nginx_conf_ssl_certificate_key if nginx_conf_ssl_certificate_key.0 != '/' else nginx_conf_ssl_certificate_key }}"
-
-- name: Configure server-wide SSL
-  template:
-    src: ssl.conf.j2
-    dest: "{{ nginx_conf_dir }}/conf.d/ssl.conf"
-    mode: 0444
-    backup: yes
-  notify:
-    - restart nginx
-    - supervisorctl restart nginx
 
 - name: Create SSL directories
   file:
@@ -36,11 +13,6 @@
   with_items:
     - "{{ nginx_conf_ssl_certificate }}"
     - "{{ nginx_conf_ssl_certificate_key }}"
-
-- name: Generate strong Diffie-Hellman group
-  command: openssl dhparam -out {{ nginx_ssl_conf_dir }}/dhparams.pem 2048
-  args:
-    creates: "{{ nginx_ssl_conf_dir }}/dhparams.pem"
 
 - name: Install SSL certificate
   copy:
@@ -58,3 +30,6 @@
     src: "{{ nginx_ssl_src_dir }}/{{ nginx_conf_ssl_trusted_certificate }}"
     dest: "{{ nginx_ssl_conf_dir }}/{{ nginx_conf_ssl_trusted_certificate }}"
   when: nginx_conf_ssl_trusted_certificate is defined
+
+- name: Include common SSL tasks
+  import_tasks: ssl-common.yml


### PR DESCRIPTION
This is useful for obtaining certs with certbot.

xref usegalaxy-eu/ansible-certbot#1