### PR TITLE
Check mode - supply fake nginx version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Make nginx -V output a single line
   set_fact:
     nginx_v: "{{ nginx_v_out.stderr | regex_replace('\\n', ' ') }}"
+  when: not ansible_check_mode
 
 - name: Register nginx-reported facts
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,12 @@
 
 - name: Admit to fake news nginx facts
   debug:
-    msg: "The nginx/openssl version cannot be detected in check mode. We have picked an arbitrary version and set that, allowing check mode to function properly. This can and will produce unexpected and untrue diffs of predicted changes, when your system nginx/openssl version differs from the arbitrary values we have chosen. You can find the correct values by running nginx -V on your server, and can override these values with --extra-vars 'nginx_version=1.12.2 nginx_openssl_version=1.0.2k'"
+    msg: >-
+      The nginx/openssl version cannot be detected in check mode. We have picked an arbitrary version and set that,
+      allowing check mode to function properly. This can and will produce unexpected and untrue diffs of predicted
+      changes, when your system nginx/openssl version differs from the arbitrary values we have chosen. You can find the
+      correct values by running nginx -V on your server, and can override these values with --extra-vars
+      'nginx_version=1.12.2 nginx_openssl_version=1.0.2k'
   when: ansible_check_mode
 
 - include_tasks: selinux.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,18 @@
   set_fact:
     nginx_version: "{{ nginx_v | regex_replace('.*nginx version: nginx/([\\d.]+).*', '\\1') }}"
     nginx_openssl_version: "{{ nginx_v | regex_replace('.*built with OpenSSL ([\\d.]+[a-z]*).*', '\\1') }}"
+  when: not ansible_check_mode
+
+- name: Register fake news nginx facts
+  set_fact:
+    nginx_version: "1.12.2"
+    nginx_openssl_version: "1.0.2k"
+  when: ansible_check_mode
+
+- name: Admit to fake news nginx facts
+  debug:
+    msg: "The nginx/openssl version cannot be detected in check mode. We have picked an arbitrary version and set that, allowing check mode to function properly. This can and will produce unexpected and untrue diffs of predicted changes, when your system nginx/openssl version differs from the arbitrary values we have chosen. You can find the correct values by running nginx -V on your server, and can override these values with --extra-vars 'nginx_version=1.12.2 nginx_openssl_version=1.0.2k'"
+  when: ansible_check_mode
 
 - include_tasks: selinux.yml
   when: ansible_selinux.status == "enabled"

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -20,3 +20,5 @@
   notify:
     - reload nginx
     - supervisorctl reload nginx
+  # Ansible will exit due to src file missing.
+  when: not ansible_check_mode


### PR DESCRIPTION
This should permit check mode to work properly-ish. When running under check mode we'll use some plausible values for nginx / nginx version (totally not fake news) and just remind the user "hey this might not be right, the diff could be unexpected, here's how to fix it"