### PR TITLE
Validate newly installed config using `nginx -t` and attempt to restore the previous config if that fails

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,12 @@ nginx_conf_dir: /etc/nginx
 nginx_conf_file: "{{ nginx_conf_dir }}/nginx.conf"
 nginx_ssl_conf_dir: "{{ nginx_conf_dir }}/ssl"
 
+# Path to the nginx binary for version and config checking (default will use whatever is on $PATH)
+nginx_command: nginx
+
+# Validate config with `nginx -t`, attempt to restore previous config upon validation failure
+nginx_check_conf: true
+
 # SSL defaults (version dependent ones such as ssl_protocols can be found in the template)
 nginx_conf_ssl_ciphers:
   - ECDHE-ECDSA-AES128-GCM-SHA256

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   when: ansible_pkg_mgr == "pkgin"
 
 - name: Collect nginx -V output
-  command: nginx -V
+  command: "{{ nginx_command }} -V"
   register: nginx_v_out
   changed_when: false
 
@@ -53,39 +53,83 @@
     - update supervisord
   when: nginx_supervisor and supervisord_conf_dir is defined
 
-- name: Set additional config options
-  template:
-    src: http_options.conf.j2
-    dest: "{{ nginx_conf_dir }}/conf.d/http_options.conf"
-    mode: 0444
-    backup: yes
-  when: nginx_conf_http is defined
-  notify:
-    - restart nginx
-    - supervisorctl restart nginx
+- name: Non-SSL configuration test block
+  block:
 
-- name: Copy additional configs
-  template:
-    src: "templates/nginx/{{ item }}.j2"
-    dest: "{{ nginx_conf_dir }}/{{ item }}"
-    mode: 0444
-    backup: yes
-  with_items: "{{ nginx_extra_configs | default([]) }}"
-  when: nginx_extra_configs is defined
+    - name: Set additional config options
+      template:
+        src: http_options.conf.j2
+        dest: "{{ nginx_conf_dir }}/conf.d/http_options.conf"
+        mode: 0444
+        backup: yes
+      when: nginx_conf_http is defined
+      register: __nginx_http_options_results
+      notify:
+        - restart nginx
+        - supervisorctl restart nginx
 
-- name: Include server (vhost) tasks
-  import_tasks: server.yml
+    - name: Copy additional configs
+      template:
+        src: "templates/nginx/{{ item }}.j2"
+        dest: "{{ nginx_conf_dir }}/{{ item }}"
+        mode: 0444
+        backup: yes
+      loop: "{{ nginx_extra_configs | default([]) }}"
+      register: __nginx_extra_configs_results
+      when: nginx_extra_configs is defined
 
-- name: Include SSL configuration tasks
-  include_tasks: ssl-{{ __nginx_sslmode }}.yml
-  when: __nginx_ssl
+    - name: Include server (vhost) tasks
+      import_tasks: server.yml
 
-- name: Include SSL server (vhost) tasks
-  #import_tasks: server.yml
-  include_tasks: server.yml
-  vars:
-    nginx_servers: "{{ nginx_ssl_servers | default([]) }}"
-  when: nginx_ssl_servers is defined
+    - name: Check non-SSL nginx config
+      command: "{{ nginx_command }} -t -c {{ nginx_conf_file }}"
+      when: nginx_check_conf and not ansible_check_mode
+      changed_when: false
+
+  rescue:
+
+    - name: Include restore tasks
+      #import_tasks: restore.yml
+      include_tasks: restore.yml
+      when: nginx_check_conf and not ansible_check_mode
+
+    # If nginx_check_conf is enabled and we're not running in Ansible check mode, this won't be reached
+    - name: Fail due to previous configuration installation errors
+      fail:
+        msg: >-
+          Installing the nginx configuration failed, so the previous configuration has been restored. Please investigate
+          the errors above for more information.
+
+- name: SSL configuration test block
+  block:
+
+    - name: Include SSL configuration tasks
+      include_tasks: ssl-{{ __nginx_sslmode }}.yml
+      when: __nginx_ssl
+
+    - name: Include SSL server (vhost) tasks
+      #import_tasks: server.yml
+      #vars:
+      #  nginx_servers: "{{ nginx_ssl_servers | default([]) }}"
+      include_tasks: ssl-server.yml
+      when: nginx_ssl_servers is defined
+
+    - name: Check SSL nginx config
+      command: "{{ nginx_command }} -t -c {{ nginx_conf_file }}"
+      when: nginx_check_conf and not ansible_check_mode
+      changed_when: false
+
+  rescue:
+
+    - name: Include restore tasks
+      include_tasks: restore.yml
+      when: nginx_check_conf and not ansible_check_mode
+
+    - name: Fail due to previous configuration installation errors
+      fail:
+        msg: >-
+          Installing the nginx SSL configuration failed, so the previous configuration has been restored. Please
+          investigate the errors above for more information.
 
 - name: Enable nginx (supervisor)
   supervisorctl:

--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -1,0 +1,122 @@
+---
+
+- name: Disable newly enabled SSL vhosts
+  file:
+    path: "{{ item.dest }}"
+    state: absent
+  loop: "{{ __nginx_ssl_server_link_results.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: __nginx_ssl_server_link_results is defined and item is changed
+
+- name: Restore SSL vhosts if previous versions exist
+  copy:
+    src: "{{ item.backup_file }}"
+    dest: "{{ item.dest }}"
+    remote_src: true
+  loop: "{{ __nginx_ssl_server_config_results.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: __nginx_ssl_server_config_results is defined and item is changed and item.backup_file is defined
+
+- name: Remove SSL vhosts if previous versions do not exist
+  file:
+    path: "{{ item.dest }}"
+    state: absent
+  loop: "{{ __nginx_ssl_server_config_results.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: __nginx_ssl_server_config_results is defined and item is changed and item.backup_file is not defined
+
+- name: Restore ssl.conf if previous version exists
+  copy:
+    src: "{{ __nginx_ssl_config_results.backup_file }}"
+    dest: "{{ nginx_conf_dir }}/conf.d/ssl.conf"
+    remote_src: true
+  when: __nginx_ssl_config_results is defined and __nginx_ssl_config_results is changed and __nginx_ssl_config_results.backup_file is defined
+
+- name: Remove ssl.conf if previous version does not exist
+  file:
+    path: "{{ nginx_conf_dir }}/conf.d/ssl.conf"
+    state: absent
+  when: ___nginx_ssl_config_results is defined and _nginx_ssl_config_results is changed and __nginx_ssl_config_results.backup_file is not defined
+
+- name: Disable newly enabled non-SSL vhosts
+  file:
+    path: "{{ item.dest }}"
+    state: absent
+  loop: "{{ __nginx_server_link_results.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: __nginx_server_link_results is defined and item is changed
+
+- name: Restore non-SSL vhosts if previous versions exist
+  copy:
+    src: "{{ item.backup_file }}"
+    dest: "{{ item.dest }}"
+    remote_src: true
+  loop: "{{ __nginx_server_config_results.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: __nginx_server_config_results is defined and item is changed and item.backup_file is defined
+
+- name: Remove non-SSL vhosts if previous versions do not exist
+  file:
+    path: "{{ item.dest }}"
+    state: absent
+  loop: "{{ __nginx_server_config_results.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: __nginx_server_config_results is defined and item is changed and item.backup_file is not defined
+
+- name: Restore extra nginx configs if previous versions exist
+  copy:
+    src: "{{ item.backup_file }}"
+    dest: "{{ item.dest }}"
+    remote_src: true
+  loop: "{{ __nginx_extra_configs_results.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: __nginx_extra_configs_results is defined and item is changed and item.backup_file is defined
+
+- name: Remove extra nginx configs if previous versions do not exist
+  file:
+    path: "{{ item.dest }}"
+    state: absent
+  loop: "{{ __nginx_extra_configs_results.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: __nginx_extra_configs_results is defined and item is changed and item.backup_file is not defined
+
+- name: Restore http_options.conf if previous version exists
+  copy:
+    src: "{{ __nginx_http_options_results.backup_file }}"
+    dest: "{{ nginx_conf_dir }}/conf.d/http_options.conf"
+    remote_src: true
+  when: __nginx_http_options_results is defined and __nginx_http_options_results is changed and __nginx_http_options_results.backup_file is defined
+
+- name: Remove http_options.conf if previous version does not exist
+  file:
+    path: "{{ nginx_conf_dir }}/conf.d/http_options.conf"
+    state: absent
+  when: ___nginx_http_options_results is defined and _nginx_http_options_results is changed and __nginx_http_options_results.backup_file is not defined
+
+# Is this useful or confusing?
+- name: Re-check config after restoring from backup
+  command: "{{ nginx_command }} -t -c {{ nginx_conf_file }}"
+  when: nginx_check_conf and not ansible_check_mode
+  changed_when: false
+  ignore_errors: true
+  register: __nginx_config_retest_results
+
+- name: Fail due to previous configuration installation or validation errors
+  fail:
+    msg: >-
+      {{ (__nginx_config_retest_results is failed) | ternary(
+              "The new nginx configuration failed to install or validate so the previous configuration was "
+              "restored, however, the restored configuration also failed to validate, meaning that the previous "
+              "configuration was invalid or it was not properly restored. Please investigate the errors above for "
+              "more information.",
+              "The new nginx configuration failed to install or validate, so the previous configuration has been "
+              "restored. Please investigate the errors above for more information." ) }}
+

--- a/tasks/ssl-common.yml
+++ b/tasks/ssl-common.yml
@@ -19,6 +19,7 @@
     dest: "{{ nginx_conf_dir }}/conf.d/ssl.conf"
     mode: 0444
     backup: yes
+  register: __nginx_ssl_config_results
   notify:
     - restart nginx
     - supervisorctl restart nginx

--- a/tasks/ssl-server.yml
+++ b/tasks/ssl-server.yml
@@ -1,24 +1,27 @@
 ---
 
-- name: Install vhost configs
+# This is almost an exact copy of server.yml, but is necessary because the register value is not templateable but must
+# be unique for restore on config test failure to work.
+
+- name: Install SSL vhost configs
   template:
     src: "{{ nginx_server_src_dir }}/{{ item }}.j2"
     dest: "{{ nginx_conf_dir }}/sites-available/{{ item | basename }}"
     mode: 0444
     backup: yes
-  loop: "{{ nginx_servers }}"
-  register: __nginx_server_config_results
+  loop: "{{ nginx_ssl_servers }}"
+  register: __nginx_ssl_server_config_results
   notify:
     - reload nginx
     - supervisorctl reload nginx
 
-- name: Enable vhosts
+- name: Enable SSL vhosts
   file:
     src: "{{ nginx_conf_dir }}/sites-available/{{ item | basename }}"
     dest: "{{ nginx_conf_dir }}/sites-enabled/{{ item | basename }}"
     state: link
-  loop: "{{ nginx_servers }}"
-  register: __nginx_server_link_results
+  loop: "{{ nginx_ssl_servers }}"
+  register: __nginx_ssl_server_link_results
   notify:
     - reload nginx
     - supervisorctl reload nginx


### PR DESCRIPTION
All of this can be disabled by setting `nginx_check_conf` to `false`, but it defaults to enabled.

There is a lot of clunkiness in the restore tasks but I don't know of a better way to do that.

xref: galaxyproject/training-material#2274