### PR TITLE
Support loading modules in EPEL nginx

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,13 @@ nginx_supervisor_service_name: nginx
 # enable ipv6 for the default vhost?
 nginx_enable_default_ipv6: true
 
+# load modules - only implemented for EL/EPEL installs
+nginx_load_modules: []
+#  - order: 50
+#    path: ngx_foo.so       # in default path /usr/lib64/nginx/modules
+#  - order: 99
+#    path: /path/to/ngx_bar.so
+
 # server block template files to install
 nginx_servers: "{{ nginx_configs | default([]) }}"
 #nginx_ssl_servers: []

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -37,7 +37,7 @@
     - restart nginx
     - supervisorctl restart nginx
 
-- name: Create virtual host directories
+- name: Create virtual host and modules directories
   file:
     path: "{{ item }}"
     state: directory
@@ -45,9 +45,22 @@
   with_items:
     - "{{ nginx_conf_dir }}/sites-available"
     - "{{ nginx_conf_dir }}/sites-enabled"
+    - "{{ nginx_conf_dir }}/modules-enabled"
   notify:
     - reload nginx
     - supervisorctl reload nginx
+
+- name: Configure module loading
+  copy:
+    dest: "/etc/nginx/modules-enabled/{{ item.order | default('50') }}-{{ item.path | basename | splitext | first }}.conf" 
+    content: |
+      ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
+      load_module {{ (item.path is abs) | ternary("", "/usr/lib64/nginx/modules/") }}{{ item.path }};
+    mode: "0644"
+  loop: "{{ nginx_load_modules }}"
+  notify:
+    - restart nginx
+    - supervisorctl restart nginx
 
 - name: Create config including virtual hosts
   copy:

--- a/templates/epel-nginx.conf.j2
+++ b/templates/epel-nginx.conf.j2
@@ -11,6 +11,7 @@ worker_processes {{ nginx_conf_worker_processes | default('auto') }};
 error_log /var/log/nginx/error.log;
 pid {{ "/run" if ansible_os_family == "RedHat" and ansible_distribution_major_version == "7" else "/var/run" }}/nginx.pid;
 daemon {{ "off" if nginx_supervisor else "on" }};
+include /etc/nginx/modules-enabled/*.conf;
 
 events {
     worker_connections {{ nginx_conf_worker_connections | default('1024') }};


### PR DESCRIPTION
Debian-based distros already have `/etc/nginx/modules-{enabled,available}`, although in a default install the `/etc/nginx/modules-enabled` symlinks are to conf files provided by the packages at `/usr/share/nginx/modules-available` and the `/etc/nginx/modules-available` dir is empty, so Debian support for this would look slightly different.