### PR TITLE
[Bugfix] Making OCSP actually optional when deploying in HTTPS mode

### DIFF
--- a/tasks/ssl-internal.yml
+++ b/tasks/ssl-internal.yml
@@ -41,8 +41,12 @@
       {{ nginx_ssl_conf_dir ~ '/' ~ nginx_conf_ssl_certificate if nginx_conf_ssl_certificate.0 != '/' else nginx_conf_ssl_certificate }}
     nginx_conf_ssl_certificate_key: >-
       {{ nginx_ssl_conf_dir ~ '/' ~ nginx_conf_ssl_certificate_key if nginx_conf_ssl_certificate_key.0 != '/' else nginx_conf_ssl_certificate_key }}
+
+- name: Make SSL trusted certificate path absolute for config
+  ansible.builtin.set_fact:   
     nginx_conf_ssl_trusted_certificate: >-
       {{ nginx_ssl_conf_dir ~ '/' ~ nginx_conf_ssl_trusted_certificate if nginx_conf_ssl_trusted_certificate.0 != '/' else nginx_conf_ssl_trusted_certificate }}
+  when: nginx_conf_ssl_trusted_certificate is defined
 
 - name: Include common SSL tasks
   ansible.builtin.import_tasks: ssl-common.yml

--- a/templates/ssl.conf.j2
+++ b/templates/ssl.conf.j2
@@ -15,7 +15,7 @@ ssl_ciphers {{ nginx_conf_ssl_ciphers | join(':') }};
 # Cert/Key
 ssl_certificate {{ nginx_ssl_conf_dir ~ '/' ~ (nginx_conf_ssl_certificate | basename) if nginx_conf_ssl_certificate.0 != '/' else nginx_conf_ssl_certificate }};
 ssl_certificate_key {{ nginx_ssl_conf_dir ~ '/' ~ (nginx_conf_ssl_certificate_key | basename) if nginx_conf_ssl_certificate_key.0 != '/' else nginx_conf_ssl_certificate_key }};
-{% if nginx_conf_ssl_stapling is defined %}
+{% if nginx_conf_ssl_stapling is defined and nginx_conf_ssl_stapling != "" %}
 
 # OCSP stapling
 ssl_stapling {{ nginx_conf_ssl_stapling }};


### PR DESCRIPTION
Hello,

In my team we don't use OCSP, and the playbook has several lines that had to be modified for the deployment to 
* not crash during deployment (see https://github.com/galaxyproject/ansible-nginx/commit/1c31a85d7db442d2f2a992b2d775ede28415c935 )
* not crash during server startup (see https://github.com/galaxyproject/ansible-nginx/pull/23/commits/aab1b206bebfa0215d20506086760352aadc5ce7 )

I made super detailed commit messages that have all the details

Technically, we could even go further:
* 1st commit: We could add 'when: " for the other variables having "/" added as well (in the same file), but I wanted to keep my changes minimal (only what is necessary to avoid a crash)
* 2nd commit: we could change all the ifs in the jinja file (at the very least the other "is defined" occurence), but again I wanted a minimize changes

Thank you