### PR TITLE
Minor updates to the EL config template

### DIFF
--- a/templates/epel-nginx.conf.j2
+++ b/templates/epel-nginx.conf.j2
@@ -9,7 +9,10 @@
 user {{ nginx_conf_user | default('nginx') }}{{ " " ~ nginx_conf_group if nginx_conf_group is defined else "" }};
 worker_processes {{ nginx_conf_worker_processes | default('auto') }};
 error_log /var/log/nginx/error.log;
-pid {{ "/run" if ansible_os_family == "RedHat" and ansible_distribution_major_version == "7" else "/var/run" }}/nginx.pid;
+pid /run/nginx.pid;
+{{ nginx_conf_root_extra | default('') }}
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
 include /etc/nginx/modules-enabled/*.conf;
 
 events {
@@ -27,7 +30,7 @@ http {
     tcp_nopush          on;
     tcp_nodelay         on;
     keepalive_timeout   65;
-    types_hash_max_size 2048;
+    types_hash_max_size {{ (ansible_distribution_major_version is version('9', '<')) | ternary(2048, 4096) }};
 
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;


### PR DESCRIPTION
Ternary for `types_hash_max_size` is due to the EL8/EL9+ defaults changing.