### PR TITLE
Cast non-boolean `when:` conditionals for ansible-core 2.18+ compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,14 +69,14 @@
 
     - name: Check non-SSL nginx config
       ansible.builtin.command: "{{ nginx_command }} -t -c {{ nginx_conf_file }}"
-      when: nginx_check_conf and not ansible_check_mode
+      when: nginx_check_conf | bool and not ansible_check_mode
       changed_when: false
 
   rescue:
 
     - name: Include restore tasks
       ansible.builtin.include_tasks: restore.yml
-      when: nginx_check_conf and not ansible_check_mode
+      when: nginx_check_conf | bool and not ansible_check_mode
 
     # If nginx_check_conf is enabled and we're not running in Ansible check mode, this won't be reached
     - name: Fail due to previous configuration installation errors
@@ -90,7 +90,7 @@
 
     - name: Include SSL configuration tasks
       ansible.builtin.include_tasks: ssl-{{ __nginx_sslmode }}.yml
-      when: __nginx_ssl
+      when: __nginx_ssl | bool
 
     - name: Include SSL server (vhost) tasks
       ansible.builtin.include_tasks: ssl-server.yml
@@ -98,14 +98,14 @@
 
     - name: Check SSL nginx config
       ansible.builtin.command: "{{ nginx_command }} -t -c {{ nginx_conf_file }}"
-      when: nginx_check_conf and not ansible_check_mode
+      when: nginx_check_conf | bool and not ansible_check_mode
       changed_when: false
 
   rescue:
 
     - name: Include restore tasks
       ansible.builtin.include_tasks: restore.yml
-      when: nginx_check_conf and not ansible_check_mode
+      when: nginx_check_conf | bool and not ansible_check_mode
 
     - name: Fail due to previous configuration installation errors
       ansible.builtin.fail:

--- a/tasks/restore.yml
+++ b/tasks/restore.yml
@@ -109,7 +109,7 @@
 # Is this useful or confusing?
 - name: Re-check config after restoring from backup
   ansible.builtin.command: "{{ nginx_command }} -t -c {{ nginx_conf_file }}"
-  when: nginx_check_conf and not ansible_check_mode
+  when: nginx_check_conf | bool and not ansible_check_mode
   changed_when: false
   ignore_errors: true
   register: __nginx_config_retest_results

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -26,4 +26,4 @@
     name: httpd_can_network_connect
     state: true
     persistent: true
-  when: nginx_selinux_allow_local_connections
+  when: nginx_selinux_allow_local_connections | bool

--- a/tasks/ssl-common.yml
+++ b/tasks/ssl-common.yml
@@ -32,4 +32,4 @@
   ansible.builtin.command: openssl dhparam -out {{ nginx_ssl_conf_dir }}/dhparams.pem 2048
   args:
     creates: "{{ nginx_conf_ssl_dhparam }}"
-  when: nginx_conf_ssl_dhparam
+  when: nginx_conf_ssl_dhparam is truthy


### PR DESCRIPTION
Fixes #25 

## Summary

ansible-core 2.18 enforces strict boolean conditionals. Several `when:` clauses in the role evaluate to `None` or strings (notably `nginx_conf_ssl_dhparam`, which is a path string, and `__nginx_ssl`, which is a stringified Jinja expression from `defaults/main.yml`). Under 2.18+ these fail with `Conditionals must have a boolean result` instead of running.

This PR adds explicit `| bool` casts (and `is truthy` for the path-valued conditional) so the role works on 2.18+ without requiring `ALLOW_BROKEN_CONDITIONALS`.

## Changes

- `tasks/ssl-common.yml`: `when: nginx_conf_ssl_dhparam` → `when: nginx_conf_ssl_dhparam is truthy` (value is a path string or `None`; `is truthy` handles both)
- `tasks/main.yml`: `when: __nginx_ssl` → `when: __nginx_ssl | bool`
- `tasks/main.yml` (×3) and `tasks/restore.yml`: `when: nginx_check_conf and not ansible_check_mode` → `when: nginx_check_conf | bool and not ansible_check_mode`
- `tasks/selinux.yml`: `when: nginx_selinux_allow_local_connections` → `when: nginx_selinux_allow_local_connections | bool`